### PR TITLE
feat: Implement TCP daemon and client for ZW MCP Phase 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,165 @@
 SmokesBowls/SmokesBowls is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+---
+
+## ZW MCP Server (Ollama Interface)
+
+This project implements a system to send ZW-formatted prompts from files to a local Ollama instance, save Ollama's responses to files, and optionally log interactions.
+
+### Directory Structure
+
+```
+zw_mcp/
+├── zw_mcp_server.py        # CLI entry point
+├── ollama_handler.py       # Handles API requests to Ollama
+├── prompts/
+│   └── example.zw          # Example ZW input prompt
+├── responses/
+│   └──                     # Directory for saved Ollama responses
+└── logs/
+    └──                     # Directory for session logs
+```
+
+### Core Scripts
+
+- **`zw_mcp/ollama_handler.py`**: Handles the low-level communication with the Ollama API (`http://localhost:11434/api/generate`).
+- **`zw_mcp/zw_mcp_server.py`**: The main command-line interface (CLI) tool. It now supports:
+    - Reading ZW-formatted prompts from an input file.
+    - Sending the prompt to a local Ollama instance.
+    - Printing Ollama's response to the console.
+    - Optionally saving Ollama's response to an output file.
+    - Optionally logging the prompt and response to a log file.
+
+### Prerequisites
+
+- Python 3
+- `requests` library (`pip install requests`)
+- A running local Ollama instance.
+
+### Usage
+
+The `zw_mcp_server.py` script is run from the root directory of the repository.
+
+**Command-line arguments:**
+
+```
+usage: zw_mcp_server.py [-h] [--out OUT] [--log LOG] infile
+
+ZW MCP ↔ Ollama
+
+positional arguments:
+  infile      Path to .zw input file (e.g., zw_mcp/prompts/example.zw)
+
+options:
+  -h, --help  show this help message and exit
+  --out OUT   Path to save Ollama response (e.g., zw_mcp/responses/ollama_response.zw)
+  --log LOG   Optional log file (e.g., zw_mcp/logs/session.log)
+```
+
+**Example:**
+
+1.  **Ensure you have an input file**, for example, `zw_mcp/prompts/example.zw` with content like:
+    ```
+    ZW-NARRATIVE-EVENT:
+      TITLE: The Awakening
+      DIALOGUE:
+        - SPEAKER: Tran
+          LINE: “This place... I’ve been here before.”
+      SCENE_GOAL: Uncover ancient resonance
+    ```
+
+2.  **Run the CLI tool from the repository root:**
+    To process an input file, save the response, and log the interaction:
+    ```bash
+    python3 zw_mcp/zw_mcp_server.py zw_mcp/prompts/example.zw --out zw_mcp/responses/response_001.zw --log zw_mcp/logs/session.log
+    ```
+
+    - This will read `zw_mcp/prompts/example.zw`.
+    - Send its content to Ollama.
+    - Print Ollama's response to the console.
+    - Save Ollama's response to `zw_mcp/responses/response_001.zw`.
+    - Append the prompt and response to `zw_mcp/logs/session.log`.
+
+    To simply process an input file and print to console:
+    ```bash
+    python3 zw_mcp/zw_mcp_server.py zw_mcp/prompts/example.zw
+    ```
+
+3.  The script will indicate that it's sending the prompt to Ollama and then print the response. If output or log paths are specified, it will also confirm saving/logging.
+```
+
+---
+
+## Phase 2: TCP Daemon Server (Networked ZW MCP)
+
+This phase transforms the ZW MCP into a network-accessible service, allowing other tools and applications to interact with it over TCP.
+
+### New Scripts for Phase 2
+
+- **`zw_mcp/zw_mcp_daemon.py`**:
+    - A TCP server that listens for incoming ZW-formatted prompts on a configurable host and port (default: `127.0.0.1:7421`).
+    - Handles multiple client connections concurrently using threading.
+    - Receives multi-line ZW input (terminated by `///`).
+    - Uses `ollama_handler.py` to query the Ollama API.
+    - Sends Ollama's response back to the connected client.
+    - Logs all incoming prompts and their corresponding responses to `zw_mcp/logs/daemon.log`.
+    - Includes error handling for network operations and graceful shutdown.
+
+- **`zw_mcp/client_example.py`**:
+    - An example CLI client to test and interact with the `zw_mcp_daemon.py`.
+    - Connects to the daemon at a specified host and port.
+    - Reads a ZW-formatted prompt from a local file (e.g., `zw_mcp/prompts/example.zw`).
+    - Sends the prompt to the daemon.
+    - Receives the daemon's response (from Ollama) and prints it to the console.
+    - Includes error handling for file and network operations.
+
+### How to Use the TCP Daemon
+
+1.  **Start the ZW MCP Daemon:**
+    Open a terminal and run the daemon script. It's recommended to run it from the root of the repository.
+    ```bash
+    python3 zw_mcp/zw_mcp_daemon.py
+    ```
+    The daemon will print a message indicating it's listening, e.g., `🌐 ZW MCP Daemon listening on 127.0.0.1:7421 ...`
+    All interactions will be logged to `zw_mcp/logs/daemon.log`.
+
+2.  **Run the Example Client (or your own tool):**
+    Open another terminal and run the client script.
+    To send the default prompt (`zw_mcp/prompts/example.zw`):
+    ```bash
+    python3 zw_mcp/client_example.py
+    ```
+    To send a specific prompt file:
+    ```bash
+    python3 zw_mcp/client_example.py path/to/your/prompt.zw
+    ```
+    The client will print the response received from the daemon.
+
+### Capabilities Unlocked
+
+This networked setup allows various external applications to interface with the ZW MCP and, by extension, with Ollama. This could include:
+- GUIs or web frontends for ZW interaction.
+- Integration with other creative tools (e.g., Blender scripts).
+- Communication between different AI agents or systems.
+
+### Directory Structure (Updated for Phase 2)
+
+The directory structure remains largely the same, with the addition of the new daemon and client scripts within `zw_mcp/`:
+```
+zw_mcp/
+├── zw_mcp_daemon.py        # NEW: TCP Daemon server
+├── client_example.py       # NEW: Example TCP client
+├── zw_mcp_server.py        # CLI tool (from Phase 1.5)
+├── ollama_handler.py       # Handles API requests to Ollama
+├── prompts/
+│   └── example.zw          # Example ZW input prompt
+├── responses/
+│   └──                     # Directory for saved CLI responses
+└── logs/
+    ├── daemon.log          # NEW: Log for TCP daemon interactions
+    └── session.log         # Log for CLI tool interactions (from Phase 1.5)
+```
+Note: The `responses/` directory is primarily used by the CLI tool (`zw_mcp_server.py`). The daemon sends responses directly back to the client.
+```

--- a/zw_mcp/client_example.py
+++ b/zw_mcp/client_example.py
@@ -1,0 +1,99 @@
+# zw_mcp/client_example.py
+import socket
+import sys
+from pathlib import Path
+
+DEFAULT_PROMPT_FILE = Path("zw_mcp/prompts/example.zw")
+BUFFER_SIZE = 4096
+DEFAULT_PORT = 7421
+DEFAULT_HOST = "127.0.0.1"
+
+def send_prompt(host: str, port: int, zw_file_path: str):
+    try:
+        with open(zw_file_path, "r", encoding="utf-8") as f:
+            prompt = f.read().strip()
+    except FileNotFoundError:
+        print(f"[!] Error: Prompt file not found at '{zw_file_path}'")
+        return
+    except Exception as e:
+        print(f"[!] Error reading prompt file '{zw_file_path}': {e}")
+        return
+
+    if not prompt:
+        print(f"[!] Error: Prompt file '{zw_file_path}' is empty.")
+        return
+
+    if not prompt.endswith("///"):
+        prompt += "\n///"
+
+    print(f"[*] Connecting to ZW MCP Daemon at {host}:{port}...")
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.connect((host, port))
+            print(f"[*] Connected. Sending prompt from '{zw_file_path}'...")
+            s.sendall(prompt.encode("utf-8"))
+            s.shutdown(socket.SHUT_WR) # Signal that sending is done
+
+            response_parts = []
+            while True:
+                try:
+                    chunk = s.recv(BUFFER_SIZE)
+                    if not chunk:
+                        break
+                    response_parts.append(chunk.decode("utf-8"))
+                except socket.timeout:
+                    print("[!] Socket timeout waiting for response.")
+                    break
+                except Exception as e:
+                    print(f"[!] Error receiving response chunk: {e}")
+                    break
+
+            if not response_parts:
+                print("[!] No response received from server.")
+                return
+
+    except socket.error as e:
+        print(f"[!] Socket error: {e}")
+        return
+    except Exception as e:
+        print(f"[!] An unexpected error occurred: {e}")
+        return
+
+    full_response = "".join(response_parts)
+    print("\n🧠 ZW MCP Response:\n")
+    print(full_response)
+
+if __name__ == "__main__":
+    host = DEFAULT_HOST
+    port = DEFAULT_PORT
+
+    # Use provided file path or default
+    if len(sys.argv) > 1:
+        zw_file_arg = sys.argv[1]
+        # Attempt to resolve relative paths, e.g. prompts/example.zw
+        # This assumes the client might be run from the root, or `zw_mcp` dir
+        possible_paths = [
+            Path(zw_file_arg),
+            Path("zw_mcp") / zw_file_arg
+        ]
+        selected_path = None
+        for p_path in possible_paths:
+            if p_path.exists():
+                selected_path = p_path
+                break
+
+        if selected_path:
+            zw_file = str(selected_path)
+        else:
+            # If not found with common prefixes, use as is and let open() handle error
+            zw_file = zw_file_arg
+            print(f"[*] Warning: Prompt file '{zw_file_arg}' not found in common locations, trying path as is.")
+
+    else:
+        zw_file = str(DEFAULT_PROMPT_FILE)
+        if not DEFAULT_PROMPT_FILE.exists():
+            print(f"[!] Error: Default prompt file '{DEFAULT_PROMPT_FILE}' not found.")
+            sys.exit(1)
+
+    print(f"[*] Using prompt file: {Path(zw_file).resolve()}")
+    send_prompt(host, port, zw_file)

--- a/zw_mcp/logs/dummy.txt
+++ b/zw_mcp/logs/dummy.txt
@@ -1,0 +1,1 @@
+This is a dummy file.

--- a/zw_mcp/ollama_handler.py
+++ b/zw_mcp/ollama_handler.py
@@ -1,0 +1,18 @@
+# ollama_handler.py
+import requests
+
+OLLAMA_URL = "http://localhost:11434/api/generate"
+MODEL_NAME = "llama3"  # or whatever you're using, e.g., "phi", "mistral"
+
+def query_ollama(prompt: str) -> str:
+    payload = {
+        "model": MODEL_NAME,
+        "prompt": prompt,
+        "stream": False  # Set True for streaming
+    }
+    try:
+        response = requests.post(OLLAMA_URL, json=payload)
+        response.raise_for_status()
+        return response.json().get("response", "").strip()
+    except Exception as e:
+        return f"ERROR: {str(e)}"

--- a/zw_mcp/prompts/dummy.txt
+++ b/zw_mcp/prompts/dummy.txt
@@ -1,0 +1,1 @@
+This is a dummy file.

--- a/zw_mcp/prompts/example.zw
+++ b/zw_mcp/prompts/example.zw
@@ -1,0 +1,6 @@
+ZW-NARRATIVE-EVENT:
+  TITLE: The Awakening
+  DIALOGUE:
+    - SPEAKER: Tran
+      LINE: “This place... I’ve been here before.”
+  SCENE_GOAL: Uncover ancient resonance

--- a/zw_mcp/responses/dummy.txt
+++ b/zw_mcp/responses/dummy.txt
@@ -1,0 +1,1 @@
+This is a dummy file.

--- a/zw_mcp/zw_mcp_daemon.py
+++ b/zw_mcp/zw_mcp_daemon.py
@@ -1,0 +1,88 @@
+# zw_mcp/zw_mcp_daemon.py
+import socket
+import threading
+from pathlib import Path
+from datetime import datetime
+from ollama_handler import query_ollama
+
+LOG_PATH = Path("zw_mcp/logs/daemon.log")
+BUFFER_SIZE = 4096
+PORT = 7421
+HOST = "127.0.0.1"  # Change to "0.0.0.0" for LAN
+
+def log(prompt: str, response: str):
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(LOG_PATH, "a", encoding="utf-8") as f:
+        f.write(f"\n--- Incoming [{datetime.now()}] ---\n{prompt}\n")
+        f.write(f"\n--- Response ---\n{response}\n")
+
+def handle_client(conn, addr):
+    print(f"[+] Connected: {addr}")
+    data = []
+    try:
+        while True:
+            chunk = conn.recv(BUFFER_SIZE).decode("utf-8")
+            if not chunk:
+                # Connection closed by client before sending "///" or anything
+                print(f"[-] Connection from {addr} closed prematurely.")
+                return
+            data.append(chunk)
+            if chunk.strip().endswith("///"):
+                break
+    except ConnectionResetError:
+        print(f"[!] Connection reset by {addr} during receive.")
+        return
+    except Exception as e:
+        print(f"[!] Error receiving data from {addr}: {e}")
+        return
+
+
+    prompt = "".join(data).strip().rstrip("///").strip()
+    if not prompt:
+        print(f"[-] Empty prompt received from {addr} after stripping '///'. Closing connection.")
+        conn.close()
+        return
+
+    print(f"[>] Received prompt from {addr}:\n{prompt}\n")
+
+    try:
+        response = query_ollama(prompt)
+        conn.sendall(response.encode("utf-8"))
+    except Exception as e:
+        print(f"[!] Error processing or sending response to {addr}: {e}")
+    finally:
+        conn.close()
+        print(f"[✔] Responded to {addr} and closed connection.")
+
+    log(prompt, response if 'response' in locals() else "ERROR: No response generated")
+
+def start_server():
+    # Ensure log directory exists at startup
+    LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            server.bind((HOST, PORT))
+        except OSError as e:
+            print(f"[!] Failed to bind to {HOST}:{PORT}: {e}")
+            return
+
+        server.listen()
+        print(f"🌐 ZW MCP Daemon listening on {HOST}:{PORT} ...")
+        print(f"ℹ️ Logging interactions to: {LOG_PATH.resolve()}")
+        while True:
+            try:
+                conn, addr = server.accept()
+                thread = threading.Thread(target=handle_client, args=(conn, addr))
+                thread.daemon = True # Allow main program to exit even if threads are running
+                thread.start()
+            except KeyboardInterrupt:
+                print("\n[!] Server shutting down...")
+                break
+            except Exception as e:
+                print(f"[!] Error accepting connection: {e}")
+                # Potentially add a small delay here if errors are too frequent
+
+if __name__ == "__main__":
+    start_server()

--- a/zw_mcp/zw_mcp_server.py
+++ b/zw_mcp/zw_mcp_server.py
@@ -1,0 +1,51 @@
+# zw_mcp_server.py
+import argparse
+from ollama_handler import query_ollama # Assuming ollama_handler.py is in the same directory or PYTHONPATH
+from pathlib import Path
+from datetime import datetime
+
+def read_zw_from_file(filepath: str) -> str:
+    with open(filepath, "r", encoding="utf-8") as f:
+        return f.read()
+
+def save_response_to_file(content: str, output_path: str):
+    # Ensure the output directory exists
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(content)
+
+def log_interaction(prompt: str, response: str, log_path: str):
+    # Ensure the log directory exists
+    Path(log_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(log_path, "a", encoding="utf-8") as f:
+        f.write(f"\n--- Prompt [{datetime.now()}] ---\n{prompt}\n")
+        f.write(f"\n--- Response ---\n{response}\n")
+
+def main():
+    parser = argparse.ArgumentParser(description="ZW MCP ↔ Ollama")
+    parser.add_argument("infile", help="Path to .zw input file (e.g., prompts/example.zw)")
+    parser.add_argument("--out", help="Path to save Ollama response (e.g., responses/ollama_response.zw)")
+    parser.add_argument("--log", help="Optional log file (e.g., logs/session.log)")
+
+    args = parser.parse_args()
+
+    # Adjust infile path if it's relative to the script location vs. execution location
+    # For now, assume paths are relative to where the script is run from.
+    zw_prompt = read_zw_from_file(args.infile)
+
+    print("🚀 Sending to Ollama...")
+    ollama_response = query_ollama(zw_prompt)
+
+    print("\n🧠 Ollama Response:\n")
+    print(ollama_response)
+
+    if args.out:
+        save_response_to_file(ollama_response, args.out)
+        print(f"\n💾 Saved response to {args.out}")
+
+    if args.log:
+        log_interaction(zw_prompt, ollama_response, args.log)
+        print(f"\n📝 Logged interaction to {args.log}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Added `zw_mcp/zw_mcp_daemon.py`: Listens for ZW-formatted input over TCP, sends it to Ollama via `ollama_handler.py`, and returns the response. Logs each interaction to `zw_mcp/logs/daemon.log`. Includes enhancements for error handling, graceful shutdown, and robust logging.
- Added `zw_mcp/client_example.py`: CLI client to send `.zw` prompt files to the daemon and print the response. Includes error handling and flexible prompt file path resolution.
- Uses port 7421 on localhost (127.0.0.1) by default for the daemon.
- `README.md` updated with a new "Phase 2: TCP Daemon Server" section, detailing the new scripts, usage instructions, and updated directory structure.
- Enables external tools (e.g., Blender, GUIs, AI agents) to interact with the ZW MCP server over a network connection.

This completes the core requirements for Phase 2, establishing a networked ZW MCP service. Future phases may unify daemon and CLI functionality.