### PR TITLE
Fix README link and add dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ZW-NARRATIVE:
 - Python 3.9+
 - [Ollama](https://ollama.ai/) (local instance)
 - Blender 3.0+
-- Required packages: `pip install requests numpy`
+- Install dependencies with `pip install -r requirements.txt`
 
 ### Installation
 ```bash
@@ -368,5 +368,5 @@ AGENT_CONFIG = {
 }
 ```
 
-**Ready to create?** Start with our [Quickstart Guide](docs/QUICKSTART.md) or explore the [Example Gallery](examples/).
+**Ready to create?** Explore the [Example Gallery](examples/) while we finalize the Quickstart guide.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
## Summary
- add `requirements.txt` with requests dependency
- fix README quickstart link
- update dependency instructions in README

## Testing
- `python3 tools/test_orbit_routing.py`

------
https://chatgpt.com/codex/tasks/task_e_684e52adc894832db1a393481c111496