### PR TITLE
Add MIT License and update README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 SmokesBowls
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ We welcome contributions! Please follow these steps:
 
 ## License
 
-Distributed under the MIT License. See `LICENSE` for more information.
+Distributed under the MIT License. See [LICENSE](LICENSE) for more information.
 
 ## Contact
 


### PR DESCRIPTION
## Summary
- add standard MIT license
- reference License file in the README

## Testing
- `python3 tools/test_orbit_routing.py` *(fails: exit code 1 for several tests)*

------
https://chatgpt.com/codex/tasks/task_e_684e52b2200c832da5c2b19000c47dcb