### PR TITLE
Fix blender_exporter.py terminal newline

### DIFF
--- a/zw_mcp/blender_exporter.py
+++ b/zw_mcp/blender_exporter.py
@@ -201,4 +201,3 @@ if __name__ == "__main__":
         print(f"[X] An unexpected error occurred in main: {e}")
 
     print("[*] ZW Exporter script finished.")
-```


### PR DESCRIPTION
## Summary
- remove stray triple backtick left at the end of `blender_exporter.py`

## Testing
- `python -m py_compile zw_mcp/blender_exporter.py`

------
https://chatgpt.com/codex/tasks/task_e_684e5daf12a4832dba19468449079d8c