### PR TITLE
Cleanup utilities and safer eval

### DIFF
--- a/tools/test_orbit_routing.py
+++ b/tools/test_orbit_routing.py
@@ -12,16 +12,6 @@ def determine_expectation(file_path: Path) -> str:
     name = file_path.name.lower()
     return "fail" if name.startswith("invalid_") else "pass"
 
-def run_test(file_path: Path) -> tuple[bool, str]:
-    expected = determine_expectation(file_path)
-    result = subprocess.run(
-        ["python3", "tools/engain_orbit.py", str(file_path)],
-        capture_output=True,
-        text=True
-    )
-    passed = (result.returncode != 0 if expected == "fail" else result.returncode == 0)
-    return passed, expected
-
 def log_result(file_path: Path, passed: bool, expected: str, result_code: int, stdout: str, stderr: str):
     timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
     with LOG_PATH.open("a", encoding="utf-8") as log:

--- a/zw_mcp/blender_adapter.py
+++ b/zw_mcp/blender_adapter.py
@@ -3,10 +3,8 @@ import sys
 import json # For potential pretty printing if needed, not directly for to_zw
 from pathlib import Path
 import argparse
-import math # Added for math.radians
-from pathlib import Path # Ensure Path is imported for handle_zw_compose_block
-from mathutils import Vector, Euler # For ZW-COMPOSE transforms
-import ast
+import math  # Added for math.radians
+from mathutils import Vector, Euler  # For ZW-COMPOSE transforms
 
 # Standardized Prefixes
 P_INFO = "[ZW->Blender][INFO]"
@@ -637,11 +635,11 @@ def handle_zw_compose_block(compose_data: dict, default_collection: bpy.types.Co
             # Handle MATERIAL_OVERRIDE for this attachment
             material_override_def = attach_def.get("MATERIAL_OVERRIDE")
             if isinstance(material_override_def, dict):
-                if ZW_MESH_UTILS_IMPORTED and APPLY_ZW_MESH_MATERIAL_FUNC:
+                if ZW_MESH_UTILS_IMPORTED and APPLY_ZW_MATERIAL_FUNC:
                     print(f"          Applying MATERIAL_OVERRIDE to '{attached_obj.name}'")
                     if 'NAME' not in material_override_def:
                         material_override_def['NAME'] = f"{attached_obj.name}_OverrideMat"
-                    APPLY_ZW_MESH_MATERIAL_FUNC(attached_obj, material_override_def)
+                    APPLY_ZW_MATERIAL_FUNC(attached_obj, material_override_def)
                 else:
                     print(f"          [Warning] MATERIAL_OVERRIDE found for '{attached_obj.name}', but zw_mesh.apply_material function was not imported.")
         else:

--- a/zw_mcp/zw_mesh.py
+++ b/zw_mcp/zw_mesh.py
@@ -2,16 +2,19 @@
 import bpy
 import math
 from pathlib import Path
-from mathutils import Vector # Explicitly import Vector
+from mathutils import Vector  # Explicitly import Vector
+import ast
 
 # Helper function (ensure this is robust or imported from a shared utility module if available)
 def safe_eval(str_val, default_val):
     if not isinstance(str_val, str):
         return default_val
     try:
-        return eval(str_val)
-    except (SyntaxError, NameError, TypeError, ValueError) as e:
-        print(f"    [!] Warning (safe_eval in zw_mesh.py): Could not evaluate string '{str_val}': {e}. Using default: {default_val}")
+        return ast.literal_eval(str_val)
+    except (ValueError, SyntaxError):
+        print(
+            f"    [!] Warning (safe_eval in zw_mesh.py): Could not evaluate string '{str_val}'. Using default: {default_val}"
+        )
         return default_val
 
 # --- Stub/Placeholder Functions (assumed to exist or be developed) ---

--- a/zwx-test-suite/test_valid_01.zwx
+++ b/zwx-test-suite/test_valid_01.zwx
@@ -1,1 +1,7 @@
-ZW-INTENT:\n  TARGET_SYSTEM: Blender\n  ROUTE_FILE: scenes/sample.zw\n---\nZW-PAYLOAD:\n  ENTITY: Cube\n  ACTION: Rotate
+ZW-INTENT:
+  TARGET_SYSTEM: Blender
+  ROUTE_FILE: scenes/sample.zw
+---
+ZW-PAYLOAD:
+  ENTITY: Cube
+  ACTION: Rotate


### PR DESCRIPTION
## Summary
- remove unused run_test helper
- deduplicate imports in `blender_adapter.py`
- use correct APPLY_ZW_MATERIAL_FUNC variable
- harden `safe_eval` using `ast.literal_eval`
- fix newline formatting in test_valid_01.zwx

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f2ba7fa00832d8e8c055cfb895e33