### PR TITLE
Fix variable name in Blender adapter

### DIFF
--- a/zw_mcp/blender_adapter.py
+++ b/zw_mcp/blender_adapter.py
@@ -511,8 +511,8 @@ def run_blender_adapter(input_filepath_str: str = None):
     try:
         print(f"{P_INFO} Parsing ZW text from '{input_filepath_str}'...")
         parsed_zw_data = parse_zw(zw_text_content)
-    if not parsed_zw_data:
-        print(f"{P_WARN} Parsed ZW data from '{input_filepath_str}' is empty. No objects will be created.")
+        if not parsed_zw_data:
+            print(f"{P_WARN} Parsed ZW data from '{input_filepath_str}' is empty. No objects will be created.")
     except Exception as e:
         print(f"{P_ERROR} Error parsing ZW text from '{input_filepath_str}': {e}")
         print(f"{P_INFO} --- ZW Blender Adapter Finished (with errors) ---")
@@ -527,7 +527,7 @@ def run_blender_adapter(input_filepath_str: str = None):
         print(f"{P_INFO} --- ZW Blender Adapter Finished (with errors) ---")
         return
 
-        print(f"{P_SUCCESS} --- ZW Blender Adapter Finished Successfully ---")
+    print(f"{P_SUCCESS} --- ZW Blender Adapter Finished Successfully ---")
 
 
 # --- ZW-COMPOSE Handler ---


### PR DESCRIPTION
## Summary
- update Blender adapter to use `input_filepath_str` correctly when parsing and processing ZW structures

## Testing
- `python3 tools/engain_orbit.py /home/tran/zw/ra4.zw` *(fails: File not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f534172fc832da1c1e99b72db6627