### PR TITLE
Fix missing handlers and unify blender adapter

### DIFF
--- a/tools/engain_orbit.py
+++ b/tools/engain_orbit.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Tuple, Optional
 
 import datetime # Added for logging timestamp
 
@@ -34,7 +35,7 @@ def log_orbit_event(message: str):
         f.write(log_entry)
 # --- End Logging Setup ---
 
-def parse_zwx_file_and_extract_raw_intent(filepath: Path) -> tuple[str | None, dict, str | None]:
+def parse_zwx_file_and_extract_raw_intent(filepath: Path) -> Tuple[Optional[str], dict, Optional[str]]:
     try:
         content = filepath.read_text(encoding="utf-8")
     except FileNotFoundError:


### PR DESCRIPTION
## Summary
- stub out missing ZW handler functions in `blender_adapter.py`
- consolidate `apply_material` import logic
- remove duplicated `run_blender_adapter` definition
- update `engain_orbit.py` typing for Python 3.9 compatibility

## Testing
- `python3 tools/test_orbit_routing.py`

------
https://chatgpt.com/codex/tasks/task_e_684f7599c9ac832db8910f85618b1e2f