### PR TITLE
Fix missing handlers in blender_adapter

### DIFF
--- a/zw_mcp/blender_adapter.py
+++ b/zw_mcp/blender_adapter.py
@@ -418,6 +418,25 @@ def handle_zw_mesh_block(mesh_data: dict, current_bpy_collection: bpy.types.Coll
     return mesh_obj
 
 
+# --- Stub Handlers for unimplemented ZW blocks ---
+def handle_zw_light_block(*args, **kwargs):
+    print("[Stub] handle_zw_light_block not yet implemented.")
+
+def handle_zw_function_block(*args, **kwargs):
+    print("[Stub] handle_zw_function_block not yet implemented.")
+
+def handle_zw_driver_block(*args, **kwargs):
+    print("[Stub] handle_zw_driver_block not yet implemented.")
+
+def handle_zw_animation_block(*args, **kwargs):
+    print("[Stub] handle_zw_animation_block not yet implemented.")
+
+def handle_zw_camera_block(*args, **kwargs):
+    print("[Stub] handle_zw_camera_block not yet implemented.")
+
+def handle_zw_stage_block(*args, **kwargs):
+    print("[Stub] handle_zw_stage_block not yet implemented.")
+
 
 
 


### PR DESCRIPTION
## Summary
- add stub handlers for ZW blocks in blender_adapter

## Testing
- `python -m py_compile zw_mcp/blender_adapter.py`
- `python -m py_compile zw_mcp/zw_mesh.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f7a49d8b4832da9cac166f6057ce3