### PR TITLE
Fix blender adapter utilities and clean Orbit script

### DIFF
--- a/tools/engain_orbit.py
+++ b/tools/engain_orbit.py
@@ -15,8 +15,6 @@ sys.path.append(str(PROJECT_ROOT))
 
 # Import the validator
 from tools.intent_utils import validate_zw_intent_block
-from zw_mcp.zw_parser import parse_zw, to_zw, prettify_zw
-
 # Placeholder for BLENDER_EXECUTABLE_PATH
 BLENDER_EXECUTABLE_PATH = "blender"
 
@@ -66,7 +64,7 @@ def parse_zwx_file_and_extract_raw_intent(filepath: Path) -> Tuple[Optional[str]
     return raw_intent_str, intent_dict, payload_str
 
 
-def route_to_blender(intent: dict, zw_payload: str, source_file_name: str): # Added source_file_name for logging
+def route_to_blender(zw_payload: str, source_file_name: str):
     print("[EngAIn-Orbit] Routing to Blender...")
     zw_payload_content = zw_payload if zw_payload is not None else ""
     with tempfile.NamedTemporaryFile("w", suffix=".zw", delete=False, encoding='utf-8') as temp:
@@ -97,7 +95,7 @@ def route_to_blender(intent: dict, zw_payload: str, source_file_name: str): # Ad
         Path(temp_path).unlink(missing_ok=True)
 
 
-def route_to_godot(intent: dict, zw_payload: str, source_file_name: str): # Added source_file_name for logging
+def route_to_godot(zw_payload: str, source_file_name: str):
     # TODO: Implement Godot routing logic
     godot_message = "[EngAIn-Orbit] Routing to Godot not implemented yet."
     print(godot_message)
@@ -141,7 +139,7 @@ def execute_orbit(zwx_file: Path):
         if payload_str and not raw_intent_str:
             print("[EngAIn-Orbit] Running direct ZW payload (no explicit ZW-INTENT block, defaulting to Blender)...")
             # Log for direct payload routing will be handled by route_to_blender
-            route_to_blender(current_intent_dict, payload_str, source_file_name)
+            route_to_blender(payload_str, source_file_name)
             return
         else:
             error_message = f"No TARGET_SYSTEM found in intent block: {source_file_name}"
@@ -158,9 +156,9 @@ def execute_orbit(zwx_file: Path):
     actual_payload_for_routing = payload_str if payload_str is not None else ""
 
     if target_system == "blender":
-        route_to_blender(current_intent_dict, actual_payload_for_routing, source_file_name)
+        route_to_blender(actual_payload_for_routing, source_file_name)
     elif target_system == "godot":
-        route_to_godot(current_intent_dict, actual_payload_for_routing, source_file_name)
+        route_to_godot(actual_payload_for_routing, source_file_name)
     else:
         error_message = f"Unknown TARGET_SYSTEM '{target_system}' in intent block for {source_file_name}."
         print(f"[ERROR] {error_message}")

--- a/zw_mcp/blender_adapter.py
+++ b/zw_mcp/blender_adapter.py
@@ -5,7 +5,8 @@ from pathlib import Path
 import argparse
 import math  # Added for math.radians
 from mathutils import Vector, Euler  # For ZW-COMPOSE transforms
-import ast
+
+from zw_mcp.utils import safe_eval, parse_color
 
 # Standardized Prefixes
 P_INFO = "[ZW->Blender][INFO]"
@@ -124,44 +125,6 @@ except ImportError:
 ZW_INPUT_FILE_PATH = Path("zw_mcp/prompts/blender_scene.zw")  # Default, can be overridden by args
 
 # --- Utility Functions ---
-def safe_eval(str_val, default_val):
-    """Safely evaluate a string to a Python literal."""
-    if not isinstance(str_val, str):
-        return default_val
-    try:
-        return ast.literal_eval(str_val)
-    except (ValueError, SyntaxError):
-        print(f"{P_WARN} safe_eval could not parse '{str_val}'. Using default {default_val}.")
-        return default_val
-
-
-def parse_color(color_val, default=(1.0, 1.0, 1.0, 1.0)):
-    """Parse a color definition from hex or tuple string formats."""
-    if not isinstance(color_val, str):
-        return default
-    val = color_val.strip()
-    if val.startswith("#"):
-        try:
-            r = int(val[1:3], 16) / 255.0
-            g = int(val[3:5], 16) / 255.0
-            b = int(val[5:7], 16) / 255.0
-            a = int(val[7:9], 16) / 255.0 if len(val) == 9 else 1.0
-            return (r, g, b, a)
-        except Exception:
-            return default
-    if val.startswith("(") and val.endswith(")"):
-        try:
-            tup = ast.literal_eval(val)
-            if isinstance(tup, (list, tuple)):
-                if len(tup) == 3:
-                    return (float(tup[0]), float(tup[1]), float(tup[2]), 1.0)
-                if len(tup) == 4:
-                    return (float(tup[0]), float(tup[1]), float(tup[2]), float(tup[3]))
-        except Exception:
-            return default
-    return default
-
-
 def get_or_create_collection(name: str, parent_collection=None):
     """Retrieve or create a Blender collection by name."""
     if not bpy:

--- a/zw_mcp/utils.py
+++ b/zw_mcp/utils.py
@@ -1,0 +1,41 @@
+import ast
+
+
+def safe_eval(str_val, default_val):
+    """Safely evaluate a string to a Python literal."""
+    if not isinstance(str_val, str):
+        return default_val
+    try:
+        return ast.literal_eval(str_val)
+    except (ValueError, SyntaxError):
+        return default_val
+
+
+def parse_color(color_val, default=(1.0, 1.0, 1.0, 1.0)):
+    """Parse a color definition from hex or tuple string formats."""
+    if not isinstance(color_val, str):
+        return default
+
+    val = color_val.strip()
+    if val.startswith("#"):
+        try:
+            r = int(val[1:3], 16) / 255.0
+            g = int(val[3:5], 16) / 255.0
+            b = int(val[5:7], 16) / 255.0
+            a = int(val[7:9], 16) / 255.0 if len(val) == 9 else 1.0
+            return (r, g, b, a)
+        except Exception:
+            return default
+
+    if val.startswith("(") and val.endswith(")"):
+        try:
+            tup = ast.literal_eval(val)
+            if isinstance(tup, (list, tuple)):
+                if len(tup) == 3:
+                    return (float(tup[0]), float(tup[1]), float(tup[2]), 1.0)
+                if len(tup) == 4:
+                    return (float(tup[0]), float(tup[1]), float(tup[2]), float(tup[3]))
+        except Exception:
+            return default
+
+    return default

--- a/zw_mcp/zw_mesh.py
+++ b/zw_mcp/zw_mesh.py
@@ -3,19 +3,8 @@ import bpy
 import math
 from pathlib import Path
 from mathutils import Vector  # Explicitly import Vector
-import ast
 
-# Helper function (ensure this is robust or imported from a shared utility module if available)
-def safe_eval(str_val, default_val):
-    if not isinstance(str_val, str):
-        return default_val
-    try:
-        return ast.literal_eval(str_val)
-    except (ValueError, SyntaxError):
-        print(
-            f"    [!] Warning (safe_eval in zw_mesh.py): Could not evaluate string '{str_val}'. Using default: {default_val}"
-        )
-        return default_val
+from zw_mcp.utils import safe_eval, parse_color
 
 # --- Stub/Placeholder Functions (assumed to exist or be developed) ---
 def create_base_mesh(mesh_def: dict):


### PR DESCRIPTION
## Summary
- centralize `safe_eval` and `parse_color` in new `utils` module
- update `blender_adapter` and `zw_mesh` to use new utilities
- clean up EngAIn-Orbit routing script and remove unused imports
- remove unused parameters in routing helpers

## Testing
- `python -m py_compile zw_mcp/utils.py zw_mcp/blender_adapter.py zw_mcp/zw_mesh.py tools/engain_orbit.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f89434988832d97bae66d48056b8f