### PR TITLE
Address lint items

### DIFF
--- a/tools/engain_orbit.py
+++ b/tools/engain_orbit.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Tuple, Optional
+from typing import Optional
 
 import datetime # Added for logging timestamp
 
@@ -33,13 +33,13 @@ def log_orbit_event(message: str):
         f.write(log_entry)
 # --- End Logging Setup ---
 
-def parse_zwx_file_and_extract_raw_intent(filepath: Path) -> Tuple[Optional[str], dict, Optional[str]]:
+def parse_zwx_file_and_extract_raw_intent(filepath: Path) -> tuple[Optional[str], dict, Optional[str]]:
     try:
         content = filepath.read_text(encoding="utf-8")
     except FileNotFoundError:
         # No print here, caller will log
         return None, {}, None
-    except Exception as e:
+    except Exception:
         # No print here, caller will log
         return None, {}, None
 

--- a/zw_mcp/blender_adapter.py
+++ b/zw_mcp/blender_adapter.py
@@ -6,7 +6,7 @@ import argparse
 import math  # Added for math.radians
 from mathutils import Vector, Euler  # For ZW-COMPOSE transforms
 
-from zw_mcp.utils import safe_eval
+from zw_mcp.utils import safe_eval, parse_color
 
 # Standardized Prefixes
 P_INFO = "[ZW->Blender][INFO]"
@@ -124,26 +124,8 @@ except ImportError:
 
 ZW_INPUT_FILE_PATH = Path("zw_mcp/prompts/blender_scene.zw")  # Default, can be overridden by args
 
-# --- Utility Functions ---
 
-def parse_color(color_input, default_color=(0.8, 0.8, 0.8, 1.0)):
-    if isinstance(color_input, str):
-        s = color_input.strip()
-        if s.startswith("#"):
-            s = s[1:]
-        try:
-            if len(s) == 6:
-                r, g, b = (int(s[i:i+2], 16) / 255.0 for i in (0, 2, 4))
-                return (r, g, b, 1.0)
-        except Exception:
-            pass
-    elif isinstance(color_input, (list, tuple)) and len(color_input) in (3, 4):
-        return (
-            tuple(float(x) for x in color_input) + (1.0,)
-            if len(color_input) == 3
-            else tuple(float(x) for x in color_input)
-        )
-    return default_color
+# --- Utility Functions ---
 
 def get_or_create_collection(name: str, parent_collection=None):
     """Retrieve or create a Blender collection by name."""

--- a/zw_mcp/ollama_agent.py
+++ b/zw_mcp/ollama_agent.py
@@ -154,7 +154,9 @@ def build_composite_prompt(seed_prompt_text: str, memory_path_str: str, limit: i
     for entry in recent_memory_entries:
         response_text = entry.get("response")
         if isinstance(response_text, str):
-            memory_block_parts.append(response_text.strip().rstrip("///").strip())
+            cleaned_resp = response_text.strip()
+            cleaned_resp = cleaned_resp.rstrip("///").strip()
+            memory_block_parts.append(cleaned_resp)
         elif response_text is not None:
             print(f"[!] Warning: Non-string response in memory: {type(response_text)}. Skipping.")
 
@@ -167,7 +169,8 @@ def build_composite_prompt(seed_prompt_text: str, memory_path_str: str, limit: i
         if memory_seed_content: # Only add if there's actual content after stripping/joining
              composite_parts.append(f"ZW-MEMORY-SEED:\n{memory_seed_content}\n///")
 
-    cleaned_seed_prompt = seed_prompt_text.strip().rstrip("///").strip()
+    cleaned_seed_prompt = seed_prompt_text.strip()
+    cleaned_seed_prompt = cleaned_seed_prompt.rstrip("///").strip()
     if cleaned_seed_prompt: # Only add if there's actual seed prompt content
         composite_parts.append(cleaned_seed_prompt)
 

--- a/zw_mcp/zw_mcp_daemon.py
+++ b/zw_mcp/zw_mcp_daemon.py
@@ -37,7 +37,8 @@ def handle_client(conn, addr):
         return
 
 
-    prompt = "".join(data).strip().rstrip("///").strip()
+    prompt = "".join(data).strip()
+    prompt = prompt.rstrip("///").strip()
     if not prompt:
         print(f"[-] Empty prompt received from {addr} after stripping '///'. Closing connection.")
         conn.close()


### PR DESCRIPTION
## Summary
- clean up string rstrip logic in daemon and agent
- import shared parse_color helper
- modernize return typing and remove unused variables

## Testing
- `python3 tools/test_orbit_routing.py`

------
https://chatgpt.com/codex/tasks/task_e_68502a062c7c832d8d010f71a2610107