### PR TITLE
Fix handlers and orbit utilities

### DIFF
--- a/tools/engain_orbit.py
+++ b/tools/engain_orbit.py
@@ -7,14 +7,13 @@ import tempfile
 from pathlib import Path
 from typing import Optional
 
+from tools.intent_utils import validate_zw_intent_block
+
 import datetime # Added for logging timestamp
 
 # Corrected sys.path modification:
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 sys.path.append(str(PROJECT_ROOT))
-
-# Import the validator
-from tools.intent_utils import validate_zw_intent_block
 # Placeholder for BLENDER_EXECUTABLE_PATH
 BLENDER_EXECUTABLE_PATH = "blender"
 
@@ -76,11 +75,13 @@ def route_to_blender(zw_payload: str, source_file_name: str):
     try:
 
         subprocess.run([
-            BLENDER_EXECUTABLE_PATH,
+            str(BLENDER_EXECUTABLE_PATH),
             "--background",
-            "--python", blender_adapter_path,
+            "--python",
+            str(blender_adapter_path),
             "--",
-        "--input", temp_path
+            "--input",
+            str(temp_path),
         ], check=True)
 
         log_orbit_event(f"✔ Routed: {source_file_name} → Blender")
@@ -107,7 +108,7 @@ def execute_orbit(zwx_file: Path):
 
     source_file_name = str(zwx_file) # For logging
 
-    if raw_intent_str is None and parsed_intent_dict == {} and payload_str is None:
+    if raw_intent_str is None and not parsed_intent_dict and payload_str is None:
         # This case implies a file read error in parse_zwx_file_and_extract_raw_intent
         # The error would have been printed by the original user code, let's log it too
         log_orbit_event(f"❌ File Error: Could not read or access {source_file_name}.")

--- a/tools/intent_utils.py
+++ b/tools/intent_utils.py
@@ -1,10 +1,13 @@
 """Utilities for handling ZW-INTENT blocks."""
 
+from typing import Union
+
+
 def get_indentation(line_text: str) -> int:
     """Calculates the leading whitespace indentation of a string."""
     return len(line_text) - len(line_text.lstrip())
 
-def validate_zw_intent_block(intent_string: str) -> dict | str:
+def validate_zw_intent_block(intent_string: str) -> Union[dict, str]:
     """
     Parses and validates a ZW-INTENT block string.
     Checks for TARGET_SYSTEM and either ROUTE_FILE or an inline ZW-PAYLOAD.

--- a/zw_mcp/blender_adapter.py
+++ b/zw_mcp/blender_adapter.py
@@ -6,7 +6,16 @@ import argparse
 import math  # Added for math.radians
 from mathutils import Vector, Euler  # For ZW-COMPOSE transforms
 
-from zw_mcp.utils import safe_eval, parse_color
+from zw_mcp.utils import safe_eval
+
+
+def parse_color(value, default=(0.8, 0.8, 0.8, 1.0)):
+    if isinstance(value, (list, tuple)) and len(value) in (3, 4):
+        parsed = tuple(float(v) for v in value[:4])
+        if len(parsed) == 3:
+            return parsed + (1.0,)
+        return parsed
+    return default
 
 # Standardized Prefixes
 P_INFO = "[ZW->Blender][INFO]"
@@ -585,6 +594,7 @@ def process_zw_structure(data_dict: dict, parent_bpy_obj=None, current_bpy_colle
 
 
 def run_blender_adapter(input_filepath_str: str = None):
+    current_zw_input_file = input_filepath_str
     print("--- Starting ZW Blender Adapter ---")
     if not bpy:
         print("[X] Blender Python environment (bpy) not detected. Cannot proceed.")


### PR DESCRIPTION
## Summary
- add type hint import and use `Union` in `validate_zw_intent_block`
- move `validate_zw_intent_block` import in `engain_orbit.py`
- harden subprocess call with `str()` casting
- check for missing intent dict using truthiness
- implement local `parse_color` and track current file in Blender adapter

## Testing
- `python -m py_compile zw_mcp/blender_adapter.py tools/engain_orbit.py tools/intent_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_6850522e860c832d869d0c473e6556d4